### PR TITLE
Add HelloWorld page

### DIFF
--- a/frontend/src/HelloWorld.js
+++ b/frontend/src/HelloWorld.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+function HelloWorld() {
+  const style = {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: '100vh'
+  };
+
+  return (
+    <div style={style}>
+      <h1>hello world !</h1>
+    </div>
+  );
+}
+
+export default HelloWorld;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import HelloWorld from './HelloWorld';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+const path = window.location.pathname;
 root.render(
   <React.StrictMode>
-    <App />
+    {path === '/helloworld' ? <HelloWorld /> : <App />}
   </React.StrictMode>
 );

--- a/src/main/kotlin/com/ykb/app/react/HelloWorldController.kt
+++ b/src/main/kotlin/com/ykb/app/react/HelloWorldController.kt
@@ -1,0 +1,12 @@
+package com.ykb.app.react
+
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+
+@Controller
+class HelloWorldController {
+    @GetMapping("/helloworld")
+    fun helloWorld(): String {
+        return "forward:/index.html"
+    }
+}


### PR DESCRIPTION
## Summary
- serve React for `/helloworld`
- add HelloWorld React component and route handling
- remove standalone HTML page

## Testing
- `./mvnw test -q` *(fails: cannot open `.mvn/wrapper/maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_6871080cca90832c81d00adbd939db2a